### PR TITLE
fix(xseed/un-gpt): fix gpt errors and fallback to data in torrent

### DIFF
--- a/xseed.sh
+++ b/xseed.sh
@@ -56,8 +56,18 @@ validate_process() {
     grep -qF "$unique_id" "$log_file" && { echo "Download ID $unique_id already processed. Exiting."; exit 0; }
 
     [ -z "$eventType" ] && { echo "No event type specified. Exiting."; exit 1; }
-    [ "$eventType" == "test" ] && { echo "Test event detected. Exiting."; exit 0; }
-    [ -z "$downloadID" ] || [ -z "$filePath" ] && { echo "Essential parameters missing. Exiting."; exit 1; }
+    [ "$eventType" == "Test" ] && { echo "Test event detected. Exiting."; exit 0; }
+    [ -z "$filePath" ] && [ -z "$downloadID" ] && { echo "Essential parameters missing. Exiting."; exit 1; } 
+
+    if [ -z "$downloadID" ] || [ -z "$filePath" ]; then
+        echo "Download ID is missing. Checking if file path works for data/path based cross-seeding."
+        if [ -z "$filePath" ]; then
+            echo "File path is missing. Exiting."
+            exit 1
+            fi
+    fi
+
+    [ -z "$filePath" ] && [ -z "$downloadID" ] && { echo "Essential parameters missing. Exiting."; exit 1; } 
 }
 
 # Main logic for handling operations
@@ -68,7 +78,7 @@ handle_operations() {
     case "$clientID" in
         "$torrentclientname")
             echo "Processing torrent client operations..."
-            xseed_resp=$(cross_seed_request "webhook" "infoHash=$downloadID")
+            [ -n "$downloadID" ] && { xseed_resp=$(cross_seed_request "webhook" "infoHash=$downloadID"); }
             [ "$xseed_resp" != "204" ] && sleep 15 && xseed_resp=$(cross_seed_request "webhook" "path=$filePath")
             ;;
         "$usenetclientname")


### PR DESCRIPTION
did the following

- [x] correct typo in eventtype (test) checking
- [x] adds fallback to data when torrent client is provided but for some reason downloadID isn't? not sure this would ever happen but why not....may future proof against v2 infohash? not sure how arrs or clients will handle this.
- [x] because of the previous thing ^^^ it will now trigger on manual imports as well, not sure if this is desired, but i don't see why it shouldn't. it is an import script, and that is an import.