### PR TITLE
fix(xseed-qbit-cat): log all pattern matches

### DIFF
--- a/xseed_qbit_cat_filter.sh
+++ b/xseed_qbit_cat_filter.sh
@@ -59,9 +59,11 @@ fi
 
 
 if [[ "$TORRENT_CAT" =~ ^($FILTERED_CAT)$ ]]; then
+  log "[\033[1m$TORRENT_NAME\033[0m] [$TORRENT_CAT]"
   xseed_resp=$(cross_seed_request "infoHash=$TORRENT_INFOHASH");
-  [ "$xseed_resp" != "204" ] && sleep 30 && xseed_resp=$(cross_seed_request "path=$TORRENT_PATH") && log "[\033[1m$TORRENT_NAME\033[0m] [$TORRENT_CAT]"
+  [ "$xseed_resp" != "204" ] && sleep 30 && xseed_resp=$(cross_seed_request "path=$TORRENT_PATH") 
 elif [[ "$TORRENT_TRACKER" =~ ($FILTERED_TRACKER) ]]; then
+  log "[\033[1m$TORRENT_NAME\033[0m] [$TORRENT_TRACKER]"
   xseed_resp=$(cross_seed_request "infoHash=$TORRENT_INFOHASH");
-  [ "$xseed_resp" != "204" ] && sleep 30 && xseed_resp=$(cross_seed_request "path=$TORRENT_PATH") && log "[\033[1m$TORRENT_NAME\033[0m] [$TORRENT_TRACKER]"
+  [ "$xseed_resp" != "204" ] && sleep 30 && xseed_resp=$(cross_seed_request "path=$TORRENT_PATH")
 fi


### PR DESCRIPTION
logs every pattern match prior to initiating a call to cross-seed

previous behavior only logged when infohash search failed and did a fall-back to data.