### PR TITLE
update(xseed.sh): usenet season pack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ All scripts are **Created By: [Bakerboy448](https://github.com/bakerboy448/) unl
 
 -   **Script:** `xseed.sh`
 -   **Description:** Triggers a cross-seed search post-import or post-upgrade in Starr applications.
+-   **Creator:** [Bakerboy448](https://github.com/bakerboy448/) with assitance from [zakkarry](https://github.com/zakkarry)
 -   **Setup:**
     1. Copy `.env.sample` to `.env`.
     2. Populate required values under "# Xseed" header.

--- a/xseed.sh
+++ b/xseed.sh
@@ -66,25 +66,6 @@ detect_application() {
         fi
         # shellcheck disable=SC2154 # These are set by Starr on call
         eventType="$sonarr_eventtype"
-    elif [ -n "$lidarr_eventtype" ]; then
-        app="lidarr"
-        # shellcheck disable=SC2154 # These are set by Starr on call
-        clientID="$lidarr_download_client"
-        # shellcheck disable=SC2154 # These are set by Starr on call
-        filePath="$lidarr_artist_path"
-        # shellcheck disable=SC2154 # These are set by Starr on call
-        downloadID="$lidarr_download_id"
-        # shellcheck disable=SC2154 # These are set by Starr on call
-        eventType="$lidarr_eventtype"
-    elif [ -n "$readarr_eventtype" ]; then
-        app="readarr"
-        # shellcheck disable=SC2154 # These are set by Starr on call
-        clientID="$readarr_download_client"
-        # shellcheck disable=SC2154 # These are set by Starr on call
-        filePath="$readarr_author_path"
-        # shellcheck disable=SC2154 # These are set by Starr on call
-        downloadID="$readarr_download_id"
-        eventType="$readarr_eventtype"
     fi
     [ "$app" == "unknown" ] && {
         echo "Unknown application type detected. Exiting."


### PR DESCRIPTION
this PR updates the script to handle usenet season pack support

also removes unsupported media types from the script (lidarr an readarr)

### notes
- usenet season pack support requires changing the event to trigger the script from on upgrade and import to "on import complete"
- falls back to old behavior if the event is not changed
- requires cross-seed v6 - if running v5 simply do not change your event type to "on import complete"