### PR TITLE
(feat) xseed.sh: Add multiple download client support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,8 +3,9 @@
 # Rename this file to .env and fill in the values accordingly.
 # Xseed
 ## Download Client Names
-TORRENT_CLIENT_NAME="" # Example: "Qbit"
-USENET_CLIENT_NAME=""  # Example: "SABnzbd"
+### For multiple clients, use format: client1,client2,client3
+TORRENT_CLIENTS="" # Examples: "Qbit", "Qbit,Deluge"
+USENET_CLIENTS=""  # Examples: "SABnzbd", "SABnzbd,SABnzbd Anime"
 ## Cross Seed API configuration
 XSEED_HOST="" # Example: "crossseed"
 XSEED_PORT="" # Example: "2468"
@@ -12,6 +13,7 @@ XSEED_PORT="" # Example: "2468"
 XSEED_APIKEY="" # Example: "your-api-key"
 ## Path to store the script's database of prior searches
 LOG_FILE="" # Example: "/config/xseed_db.log"
+LOGID_FILE="" # Example: "/config/xseed-id.log"
 # ZFS Destory
 VERBOSE=0
 MAX_FREQ=2

--- a/.env.sample
+++ b/.env.sample
@@ -3,8 +3,9 @@
 # Rename this file to .env and fill in the values accordingly.
 # Xseed
 ## Download Client Names
-TORRENT_CLIENT_NAME="" # Example: "Qbit"
-USENET_CLIENT_NAME=""  # Example: "SABnzbd"
+### For multiple clients, use format: client1,client2,client3
+TORRENT_CLIENTS="" # Examples: "Qbit", "Qbit,Deluge"
+USENET_CLIENTS=""  # Examples: "SABnzbd", "SABnzbd,SABnzbd Anime"
 ## Cross Seed API configuration
 XSEED_HOST="" # Example: "crossseed"
 XSEED_PORT="" # Example: "2468"

--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,8 @@
 # Rename this file to .env and fill in the values accordingly.
 # Xseed
 ## Download Client Names
-### For multiple clients, use format: client1,client2,client3
+### For multiple clients, use format: "client1,client2,client3"
+### Do not include extra spaces around commas!
 TORRENT_CLIENTS="" # Examples: "Qbit", "Qbit,Deluge"
 USENET_CLIENTS=""  # Examples: "SABnzbd", "SABnzbd,SABnzbd Anime"
 ## Cross Seed API configuration

--- a/xseed.sh
+++ b/xseed.sh
@@ -8,7 +8,7 @@
 
 # Load environment variables from .env file if it exists
 # in the same directory as this bash script
-VERSION='3.2.0'
+VERSION='4.0.0'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_PATH="$SCRIPT_DIR/.env"
 OLD_IFS="$IFS"

--- a/xseed.sh
+++ b/xseed.sh
@@ -8,7 +8,7 @@
 
 # Load environment variables from .env file if it exists
 # in the same directory as this bash script
-VERSION='3.2.0'
+VERSION='4.0.0'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_PATH="$SCRIPT_DIR/.env"
 

--- a/xseed.sh
+++ b/xseed.sh
@@ -96,7 +96,10 @@ is_valid_client() {
         done
     fi
     
-    echo "$valid"
+    if [[ "$valid" == "true" ]]; then
+        return 0
+    fi
+    return 1
 }
 
 # Function to send a request to Cross Seed API

--- a/xseed.sh
+++ b/xseed.sh
@@ -230,7 +230,7 @@ handle_operations() {
             send_data_search
         fi
     # Check if client is a usenet client
-    elif [ "$(is_valid_client "$clientID" "usenet")" == "true" ]; then
+    elif is_valid_client "$clientID" "usenet"; then
         if [ -z "$sonarrReleaseType" ] && [[ "$folderPath" =~ S[0-9]{1,2}(?!\.E[0-9]{1,2}) ]]; then
             log_message "WARN" "Depreciated Action. Skipping season pack search. Please switch to On Import Complete for Usenet Season Pack Support!"
             exit 0

--- a/xseed.sh
+++ b/xseed.sh
@@ -64,11 +64,6 @@ IFS=',' read -r -a USENET_CLIENT_ARRAY <<< "$USENET_CLIENTS"
 # Restore original IFS
 IFS="$OLD_IFS"
 
-# Trim whitespace from array elements
-TORRENT_CLIENT_ARRAY=("${TORRENT_CLIENT_ARRAY[@]/#[[:space:]]/}")
-TORRENT_CLIENT_ARRAY=("${TORRENT_CLIENT_ARRAY[@]/%[[:space:]]/}")
-USENET_CLIENT_ARRAY=("${USENET_CLIENT_ARRAY[@]/#[[:space:]]/}")
-USENET_CLIENT_ARRAY=("${USENET_CLIENT_ARRAY[@]/%[[:space:]]/}")
 
 log_message "DEBUG" "Using '.env' file for config?: $EVAR"
 log_message "INFO" "Using configuration:"

--- a/xseed.sh
+++ b/xseed.sh
@@ -78,27 +78,24 @@ log_message "INFO" "LOGID_FILE=$LOGID_FILE"
 is_valid_client() {
     local client="$1"
     local client_type="$2"
-    local valid=false
-    
-    if [ "$client_type" == "torrent" ]; then
-        for allowed_client in "${TORRENT_CLIENT_ARRAY[@]}"; do
-            if [ "$client" == "$allowed_client" ]; then
-                valid=true
-                break
-            fi
-        done
-    elif [ "$client_type" == "usenet" ]; then
-        for allowed_client in "${USENET_CLIENT_ARRAY[@]}"; do
-            if [ "$client" == "$allowed_client" ]; then
-                valid=true
-                break
-            fi
-        done
-    fi
-    
-    if [[ "$valid" == "true" ]]; then
-        return 0
-    fi
+    case $client_type in
+        "torrent")
+            for allowed_client in "${TORRENT_CLIENTS[@]}"; do
+                if [[ "$client" == "$allowed_client" ]]; then
+                    return 0
+                    break
+                fi
+            done
+            ;;
+        "usenet")
+            for allowed_client in "${USENET_CLIENTS[@]}"; do
+                if [[ "$client" == "$allowed_client" ]]; then
+                    return 0
+                    break
+                fi
+            done
+            ;;
+    esac
     return 1
 }
 

--- a/xseed.sh
+++ b/xseed.sh
@@ -43,9 +43,11 @@ else
 fi
 
 # Use environment variables with descriptive default values
-# For multiple clients, use format: client1,client2,client3
-TORRENT_CLIENTS=${TORRENT_CLIENTS:-"Qbit"}
-USENET_CLIENTS=${USENET_CLIENTS:-"SABnzbd"}
+# format for up to as many clients as you need 
+# Multiple clients: (${TORRENT_CLIENTS:-"Qbit","Qbit2"})
+# Single Client: (${TORRENT_CLIENTS:-"Qbit"})
+TORRENT_CLIENTS=(${TORRENT_CLIENTS:-"Qbit"})
+USENET_CLIENTS=(${USENET_CLIENTS:-"SABnzbd"})
 XSEED_HOST=${XSEED_HOST:-crossseed}
 XSEED_PORT=${XSEED_PORT:-8080}
 LOG_FILE=${LOG_FILE:-/config/xseed.log}

--- a/xseed.sh
+++ b/xseed.sh
@@ -52,9 +52,21 @@ LOG_FILE=${LOG_FILE:-/config/xseed.log}
 LOGID_FILE=${LOGID_FILE:-/config/xseed-id.log}
 XSEED_APIKEY=${XSEED_APIKEY:-}
 
+# Save original IFS
+OLD_IFS="$IFS"
+
 # Convert comma-separated strings to arrays
 IFS=',' read -r -a TORRENT_CLIENT_ARRAY <<< "$TORRENT_CLIENTS"
 IFS=',' read -r -a USENET_CLIENT_ARRAY <<< "$USENET_CLIENTS"
+
+# Restore original IFS
+IFS="$OLD_IFS"
+
+# Trim whitespace from array elements
+TORRENT_CLIENT_ARRAY=("${TORRENT_CLIENT_ARRAY[@]/#[[:space:]]/}")
+TORRENT_CLIENT_ARRAY=("${TORRENT_CLIENT_ARRAY[@]/%[[:space:]]/}")
+USENET_CLIENT_ARRAY=("${USENET_CLIENT_ARRAY[@]/#[[:space:]]/}")
+USENET_CLIENT_ARRAY=("${USENET_CLIENT_ARRAY[@]/%[[:space:]]/}")
 
 log_message "DEBUG" "Using '.env' file for config?: $EVAR"
 log_message "INFO" "Using configuration:"

--- a/xseed.sh
+++ b/xseed.sh
@@ -220,7 +220,7 @@ handle_operations() {
     validate_process
     
     # Check if client is a torrent client
-    if [ "$(is_valid_client "$clientID" "torrent")" == "true" ]; then
+    if is_valid_client "$clientID" "torrent"; then
         log_message "INFO" "Processing torrent client operations for $clientID..."
         if [ -n "$downloadID" ]; then
             xseed_resp=$(cross_seed_request "webhook" "infoHash=$downloadID")

--- a/xseed.sh
+++ b/xseed.sh
@@ -43,9 +43,11 @@ else
 fi
 
 # Use environment variables with descriptive default values
-# For multiple clients, use format: client1,client2,client3
-TORRENT_CLIENTS=${TORRENT_CLIENTS:-"Qbit"}
-USENET_CLIENTS=${USENET_CLIENTS:-"SABnzbd"}
+# format for up to as many clients as you need 
+# Multiple clients: (${TORRENT_CLIENTS:-"Qbit","Qbit2"})
+# Single Client: (${TORRENT_CLIENTS:-"Qbit"})
+TORRENT_CLIENTS=(${TORRENT_CLIENTS:-"Qbit"})
+USENET_CLIENTS=(${USENET_CLIENTS:-"SABnzbd"})
 XSEED_HOST=${XSEED_HOST:-crossseed}
 XSEED_PORT=${XSEED_PORT:-8080}
 LOG_FILE=${LOG_FILE:-/config/xseed.log}
@@ -62,11 +64,6 @@ IFS=',' read -r -a USENET_CLIENT_ARRAY <<< "$USENET_CLIENTS"
 # Restore original IFS
 IFS="$OLD_IFS"
 
-# Trim whitespace from array elements
-TORRENT_CLIENT_ARRAY=("${TORRENT_CLIENT_ARRAY[@]/#[[:space:]]/}")
-TORRENT_CLIENT_ARRAY=("${TORRENT_CLIENT_ARRAY[@]/%[[:space:]]/}")
-USENET_CLIENT_ARRAY=("${USENET_CLIENT_ARRAY[@]/#[[:space:]]/}")
-USENET_CLIENT_ARRAY=("${USENET_CLIENT_ARRAY[@]/%[[:space:]]/}")
 
 log_message "DEBUG" "Using '.env' file for config?: $EVAR"
 log_message "INFO" "Using configuration:"


### PR DESCRIPTION
I (and perhaps others?) use granular settings on the *arr side to send downloads to different client profiles, each with their own category/download folder/etc., which takes some burden off individual clients for supporting various features on their end. This PR:
- Allows for specifying a comma-delimited list of download client names, instead of just one
- Updates `.env.sample` with comments and examples (and also adds `$LOGID_FILE`, which might have been missing from #24)

Granular changes:
- Variable names (code and `.env`): `$[TORRENT|USENET]_CLIENT_NAME` -> `$[TORRENT|USENET]_CLIENTS`
- Loads client strings and converts to Bash array (tolerates leading/trailing spaces and saves/restores IFS)
- Replaces `case` statements with a validation function (`is_valid_client`) and `if`/`elif`)

Feel free to discard this if it's outside what you wish for the script, I just made the modifications for my own setup and thought I'd give back :)
