### PR TITLE
chore(style): bulk shfmt v3.13.1 reformat across all scripts

### DIFF
--- a/dupe.sh
+++ b/dupe.sh
@@ -6,17 +6,17 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_PATH="$SCRIPT_DIR/.env"
 if [ -f "$ENV_PATH" ]; then
-    # shellcheck source=.env
-    echo "Loading environment variables from $ENV_PATH file"
-    # shellcheck disable=SC1090 # shellcheck sucks
-    if source "$ENV_PATH"; then
-        echo "Environment variables loaded successfully"
-    else
-        echo "Error loading environment variables" >&2
-        exit 1
-    fi
+  # shellcheck source=.env
+  echo "Loading environment variables from $ENV_PATH file"
+  # shellcheck disable=SC1090 # shellcheck sucks
+  if source "$ENV_PATH"; then
+    echo "Environment variables loaded successfully"
+  else
+    echo "Error loading environment variables" >&2
+    exit 1
+  fi
 else
-    echo ".env file not found in script directory ($ENV_PATH)"
+  echo ".env file not found in script directory ($ENV_PATH)"
 fi
 
 # Default Variables
@@ -30,52 +30,52 @@ JDUPES_INCLUDE_EXT=${JDUPES_INCLUDE_EXT:-"mp4,mkv,avi"}
 DEBUG=${DEBUG:-"false"}
 
 find_duplicates() {
-    local log_file="$JDUPES_OUTPUT_LOG"
-    local start_time
-    start_time=$(date +%s)
-    echo "[$(date +"%Y-%m-%d %H:%M:%S")] Duplicate search started" | tee -a "$log_file"
+  local log_file="$JDUPES_OUTPUT_LOG"
+  local start_time
+  start_time=$(date +%s)
+  echo "[$(date +"%Y-%m-%d %H:%M:%S")] Duplicate search started" | tee -a "$log_file"
 
-    if [ "$DEBUG" == "true" ]; then
-        echo "Running jdupes with:" | tee -a "$log_file"
-        echo "$JDUPES_COMMAND $JDUPES_EXCLUDE_DIRS -X onlyext:$JDUPES_INCLUDE_EXT -r -M -y $JDUPES_HASH_DB $JDUPES_SOURCE_DIR $JDUPES_DESTINATION_DIR" | tee -a "$log_file"
-    fi
+  if [ "$DEBUG" == "true" ]; then
+    echo "Running jdupes with:" | tee -a "$log_file"
+    echo "$JDUPES_COMMAND $JDUPES_EXCLUDE_DIRS -X onlyext:$JDUPES_INCLUDE_EXT -r -M -y $JDUPES_HASH_DB $JDUPES_SOURCE_DIR $JDUPES_DESTINATION_DIR" | tee -a "$log_file"
+  fi
 
-    local results
+  local results
+  # shellcheck disable=SC2086
+  results=$("$JDUPES_COMMAND" $JDUPES_EXCLUDE_DIRS -X onlyext:"$JDUPES_INCLUDE_EXT" -r -M -y "$JDUPES_HASH_DB" "$JDUPES_SOURCE_DIR" "$JDUPES_DESTINATION_DIR")
+
+  if [[ $results != *"No duplicates found."* ]]; then
     # shellcheck disable=SC2086
-    results=$("$JDUPES_COMMAND" $JDUPES_EXCLUDE_DIRS -X onlyext:"$JDUPES_INCLUDE_EXT" -r -M -y "$JDUPES_HASH_DB" "$JDUPES_SOURCE_DIR" "$JDUPES_DESTINATION_DIR")
+    "$JDUPES_COMMAND" $JDUPES_EXCLUDE_DIRS -X onlyext:"$JDUPES_INCLUDE_EXT" -r -L -y "$JDUPES_HASH_DB" "$JDUPES_SOURCE_DIR" "$JDUPES_DESTINATION_DIR" >>"$log_file"
+  fi
 
-    if [[ $results != *"No duplicates found."* ]]; then
-        # shellcheck disable=SC2086
-        "$JDUPES_COMMAND" $JDUPES_EXCLUDE_DIRS -X onlyext:"$JDUPES_INCLUDE_EXT" -r -L -y "$JDUPES_HASH_DB" "$JDUPES_SOURCE_DIR" "$JDUPES_DESTINATION_DIR" >>"$log_file"
-    fi
+  if [ "$DEBUG" == "true" ]; then
+    echo -e "jdupes output: ${results}" | tee -a "$log_file"
+  fi
 
-    if [ "$DEBUG" == "true" ]; then
-        echo -e "jdupes output: ${results}" | tee -a "$log_file"
-    fi
-
-    parse_jdupes_output "$results" "$log_file"
-    local finish_time
-    finish_time=$(date +%s)
-    local run_time=$((finish_time - start_time))
-    echo "[$(date +"%Y-%m-%d %H:%M:%S")] Duplicate search completed in ${run_time}s" | tee -a "$log_file"
+  parse_jdupes_output "$results" "$log_file"
+  local finish_time
+  finish_time=$(date +%s)
+  local run_time=$((finish_time - start_time))
+  echo "[$(date +"%Y-%m-%d %H:%M:%S")] Duplicate search completed in ${run_time}s" | tee -a "$log_file"
 }
 
 parse_jdupes_output() {
-    local results="$1"
-    local log_file="$2"
+  local results="$1"
+  local log_file="$2"
 
-    if [[ $results != *"No duplicates found."* ]]; then
-        field_message="❌ Unlinked files discovered..."
-        parsed_log=$(echo "$results" | awk -F/ '{print $NF}' | sort -u)
-    else
-        field_message="✅ No unlinked files discovered..."
-        parsed_log="No hardlinks created"
-    fi
+  if [[ $results != *"No duplicates found."* ]]; then
+    field_message="❌ Unlinked files discovered..."
+    parsed_log=$(echo "$results" | awk -F/ '{print $NF}' | sort -u)
+  else
+    field_message="✅ No unlinked files discovered..."
+    parsed_log="No hardlinks created"
+  fi
 
-    if [ "$DEBUG" == "true" ]; then
-        echo -e "$field_message" | tee -a "$log_file"
-        echo -e "Parsed log: ${parsed_log}" | tee -a "$log_file"
-    fi
+  if [ "$DEBUG" == "true" ]; then
+    echo -e "$field_message" | tee -a "$log_file"
+    echo -e "Parsed log: ${parsed_log}" | tee -a "$log_file"
+  fi
 }
 
 find_duplicates

--- a/f2b-dump.sh
+++ b/f2b-dump.sh
@@ -5,10 +5,10 @@ temp_file=$(mktemp)
 
 # Function to add content to the temporary file
 add_content() {
-    # shellcheck disable=SC2129
-    echo -e "\n$1\n" >>"$temp_file"
-    cat "$2" >>"$temp_file" 2>/dev/null
-    echo -e "\n" >>"$temp_file"
+  # shellcheck disable=SC2129
+  echo -e "\n$1\n" >>"$temp_file"
+  cat "$2" >>"$temp_file" 2>/dev/null
+  echo -e "\n" >>"$temp_file"
 }
 
 # List all active jails
@@ -18,8 +18,8 @@ fail2ban-client status >>"$temp_file"
 # Get status for each jail
 jails=$(fail2ban-client status | grep 'Jail list:' | sed -E 's/^[^:]+:\s+//;s/,//g')
 for jail in $jails; do
-    echo -e "\nStatus of $jail jail:\n" >>"$temp_file"
-    fail2ban-client status "$jail" >>"$temp_file"
+  echo -e "\nStatus of $jail jail:\n" >>"$temp_file"
+  fail2ban-client status "$jail" >>"$temp_file"
 done
 
 # Global configurations
@@ -29,8 +29,8 @@ add_content "Custom Global Configuration (/etc/fail2ban/jail.local):" "/etc/fail
 # Custom jail configurations in jail.d/
 echo "Custom Jail Configurations in /etc/fail2ban/jail.d/:" >>"$temp_file"
 for config_file in /etc/fail2ban/jail.d/*; do
-    [ -e "$config_file" ] || continue
-    add_content "Custom Jail Configuration ($config_file):" "$config_file"
+  [ -e "$config_file" ] || continue
+  add_content "Custom Jail Configuration ($config_file):" "$config_file"
 done
 
 # Upload to termbin

--- a/omegabrr_upgrade.sh
+++ b/omegabrr_upgrade.sh
@@ -5,20 +5,20 @@ service_name="omegabrr@bakerboy448"
 
 # Function to handle errors and exit
 handle_error() {
-    echo "Error: $1" >&2
-    exit 1
+  echo "Error: $1" >&2
+  exit 1
 }
 
 # Get the old version of omegabrr
 old_version=$(omegabrr version)
 
 # Fetch the URL of the latest release for linux_x86_64
-dlurl=$(curl -s https://api.github.com/repos/autobrr/omegabrr/releases/latest |
-    grep -E 'browser_download_url.*linux_x86_64' | cut -d\" -f4)
+dlurl=$(curl -s https://api.github.com/repos/autobrr/omegabrr/releases/latest \
+  | grep -E 'browser_download_url.*linux_x86_64' | cut -d\" -f4)
 
 # Validate the download URL
 if [ -z "$dlurl" ]; then
-    handle_error "Failed to fetch download URL."
+  handle_error "Failed to fetch download URL."
 fi
 
 # Download the latest release

--- a/pic-update.sh
+++ b/pic-update.sh
@@ -15,48 +15,48 @@ CURRENT_UID=$(id -u)
 
 # Check if Plex-Image-Cleanup is installed and the current user owns it
 check_pic_installation() {
-    if [ -d "$PIC_PATH" ]; then
-        local pic_repo_owner
-        pic_repo_owner=$(stat -c '%u' "$PIC_PATH")
-        if [ "$pic_repo_owner" != "$CURRENT_UID" ]; then
-            echo "You do not own the Plex-Image-Cleanup repo. Please run this script as the user that owns the repo [$pic_repo_owner]."
-            exit 1
-        fi
-    else
-        echo "Plex-Image-Cleanup folder does not exist. Please install Plex-Image-Cleanup before running this script."
-        exit 1
+  if [ -d "$PIC_PATH" ]; then
+    local pic_repo_owner
+    pic_repo_owner=$(stat -c '%u' "$PIC_PATH")
+    if [ "$pic_repo_owner" != "$CURRENT_UID" ]; then
+      echo "You do not own the Plex-Image-Cleanup repo. Please run this script as the user that owns the repo [$pic_repo_owner]."
+      exit 1
     fi
+  else
+    echo "Plex-Image-Cleanup folder does not exist. Please install Plex-Image-Cleanup before running this script."
+    exit 1
+  fi
 }
 
 # Update Plex-Image-Cleanup if necessary
 update_pic() {
-    current_branch=$(git -C "$PIC_PATH" rev-parse --abbrev-ref HEAD)
-    echo "Current Branch: $current_branch. Checking for updates..."
-    git -C "$PIC_PATH" fetch
-    if [ "$(git -C "$PIC_PATH" rev-parse HEAD)" = "$(git -C "$PIC_PATH" rev-parse @'{u}')" ] && [ "$force_update" != true ]; then
-        current_version=$(cat "$PIC_VERSION_FILE")
-        echo "=== Already up to date $current_version on $current_branch ==="
-        exit 0
-    fi
-    git -C "$PIC_PATH" reset --hard "$PIC_UPSTREAM_GIT_REMOTE/$current_branch"
+  current_branch=$(git -C "$PIC_PATH" rev-parse --abbrev-ref HEAD)
+  echo "Current Branch: $current_branch. Checking for updates..."
+  git -C "$PIC_PATH" fetch
+  if [ "$(git -C "$PIC_PATH" rev-parse HEAD)" = "$(git -C "$PIC_PATH" rev-parse @'{u}')" ] && [ "$force_update" != true ]; then
+    current_version=$(cat "$PIC_VERSION_FILE")
+    echo "=== Already up to date $current_version on $current_branch ==="
+    exit 0
+  fi
+  git -C "$PIC_PATH" reset --hard "$PIC_UPSTREAM_GIT_REMOTE/$current_branch"
 }
 
 # Update venv if necessary
 update_venv() {
-    current_requirements=$(sha1sum "$PIC_REQUIREMENTS_FILE" | awk '{print $1}')
-    new_requirements=$(sha1sum "$PIC_REQUIREMENTS_FILE" | awk '{print $1}')
-    if [ "$current_requirements" != "$new_requirements" ] || [ "$force_update" = true ]; then
-        echo "=== Requirements changed, updating venv ==="
-        "$PIC_VENV_PATH/bin/python3" "$PIC_VENV_PATH/bin/pip" install -r "$PIC_REQUIREMENTS_FILE"
-    fi
+  current_requirements=$(sha1sum "$PIC_REQUIREMENTS_FILE" | awk '{print $1}')
+  new_requirements=$(sha1sum "$PIC_REQUIREMENTS_FILE" | awk '{print $1}')
+  if [ "$current_requirements" != "$new_requirements" ] || [ "$force_update" = true ]; then
+    echo "=== Requirements changed, updating venv ==="
+    "$PIC_VENV_PATH/bin/python3" "$PIC_VENV_PATH/bin/pip" install -r "$PIC_REQUIREMENTS_FILE"
+  fi
 }
 
 # Restart the Plex-Image-Cleanup service
 restart_service() {
-    echo "=== Restarting Plex-Image-Cleanup Service ==="
-    sudo systemctl restart "$PIC_SERVICE_NAME"
-    new_version=$(cat "$PIC_VERSION_FILE")
-    echo "=== Updated to $new_version on $current_branch ==="
+  echo "=== Restarting Plex-Image-Cleanup Service ==="
+  sudo systemctl restart "$PIC_SERVICE_NAME"
+  new_version=$(cat "$PIC_VERSION_FILE")
+  echo "=== Updated to $new_version on $current_branch ==="
 }
 
 # Main script execution

--- a/pmm-update.sh
+++ b/pmm-update.sh
@@ -16,47 +16,47 @@ CURRENT_UID=$(id -u)
 
 # Check if PMM is installed and the current user owns it
 check_pmm_installation() {
-    if [ -d "$PMM_PATH" ]; then
-        pmm_repo_owner=$(stat -c '%u' "$PMM_PATH")
-        if [ "$pmm_repo_owner" != "$CURRENT_UID" ]; then
-            echo "You do not own the Plex Meta Manager repo. Please run this script as the user that owns the repo [$pmm_repo_owner]."
-            exit 1
-        fi
-    else
-        echo "Plex Meta Manager folder does not exist. Please install Plex Meta Manager before running this script."
-        exit 1
+  if [ -d "$PMM_PATH" ]; then
+    pmm_repo_owner=$(stat -c '%u' "$PMM_PATH")
+    if [ "$pmm_repo_owner" != "$CURRENT_UID" ]; then
+      echo "You do not own the Plex Meta Manager repo. Please run this script as the user that owns the repo [$pmm_repo_owner]."
+      exit 1
     fi
+  else
+    echo "Plex Meta Manager folder does not exist. Please install Plex Meta Manager before running this script."
+    exit 1
+  fi
 }
 
 # Update PMM if necessary
 update_pmm() {
-    current_branch=$(git -C "$PMM_PATH" rev-parse --abbrev-ref HEAD)
-    echo "Current Branch: $current_branch. Checking for updates..."
-    git -C "$PMM_PATH" fetch
-    if [ "$(git -C "$PMM_PATH" rev-parse HEAD)" = "$(git -C "$PMM_PATH" rev-parse @'{u}')" ] && [ "$force_update" != true ]; then
-        current_version=$(cat "$PMM_VERSION_FILE")
-        echo "=== Already up to date $current_version on $current_branch ==="
-        exit 0
-    fi
-    git -C "$PMM_PATH" reset --hard "$PMM_UPSTREAM_GIT_REMOTE/$current_branch"
+  current_branch=$(git -C "$PMM_PATH" rev-parse --abbrev-ref HEAD)
+  echo "Current Branch: $current_branch. Checking for updates..."
+  git -C "$PMM_PATH" fetch
+  if [ "$(git -C "$PMM_PATH" rev-parse HEAD)" = "$(git -C "$PMM_PATH" rev-parse @'{u}')" ] && [ "$force_update" != true ]; then
+    current_version=$(cat "$PMM_VERSION_FILE")
+    echo "=== Already up to date $current_version on $current_branch ==="
+    exit 0
+  fi
+  git -C "$PMM_PATH" reset --hard "$PMM_UPSTREAM_GIT_REMOTE/$current_branch"
 }
 
 # Update venv if necessary
 update_venv() {
-    current_requirements=$(sha1sum "$PMM_REQUIREMENTS_FILE" | awk '{print $1}')
-    new_requirements=$(sha1sum "$PMM_REQUIREMENTS_FILE" | awk '{print $1}')
-    if [ "$current_requirements" != "$new_requirements" ] || [ "$force_update" = true ]; then
-        echo "=== Requirements changed, updating venv ==="
-        "$PMM_VENV_PATH/bin/python3" "$PMM_VENV_PATH/bin/pip" install -r "$PMM_REQUIREMENTS_FILE"
-    fi
+  current_requirements=$(sha1sum "$PMM_REQUIREMENTS_FILE" | awk '{print $1}')
+  new_requirements=$(sha1sum "$PMM_REQUIREMENTS_FILE" | awk '{print $1}')
+  if [ "$current_requirements" != "$new_requirements" ] || [ "$force_update" = true ]; then
+    echo "=== Requirements changed, updating venv ==="
+    "$PMM_VENV_PATH/bin/python3" "$PMM_VENV_PATH/bin/pip" install -r "$PMM_REQUIREMENTS_FILE"
+  fi
 }
 
 # Restart the PMM service
 restart_service() {
-    echo "=== Restarting PMM Service ==="
-    sudo systemctl restart "$PMM_SERVICE_NAME"
-    new_version=$(cat "$PMM_VERSION_FILE")
-    echo "=== Updated to $new_version on $current_branch"
+  echo "=== Restarting PMM Service ==="
+  sudo systemctl restart "$PMM_SERVICE_NAME"
+  new_version=$(cat "$PMM_VERSION_FILE")
+  echo "=== Updated to $new_version on $current_branch"
 }
 
 # Main script execution

--- a/qbm-api-trigger.sh
+++ b/qbm-api-trigger.sh
@@ -23,8 +23,8 @@ API_URL="http://127.0.0.1:4269/api/run-command"
 COMMANDS='["tag_update", "share_limits", "rem_unregistered", "recheck"]'
 
 if [[ $# -lt 1 || -z "$1" ]]; then
-    echo "Usage: $0 <torrent_hash>" >&2
-    exit 1
+  echo "Usage: $0 <torrent_hash>" >&2
+  exit 1
 fi
 
 TORRENT_HASH="$1"
@@ -34,15 +34,15 @@ LOG_FILE="${SCRIPT_DIR}/run_qbit_manage_commands.log"
 JSON="{\"commands\":${COMMANDS},\"hashes\":[\"${TORRENT_HASH}\"]}"
 
 {
-    echo "Sending API call for hash: ${TORRENT_HASH}"
-    echo "Payload: ${JSON}"
+  echo "Sending API call for hash: ${TORRENT_HASH}"
+  echo "Payload: ${JSON}"
 } | tee -a "${LOG_FILE}"
 
 if curl -fsSL -X POST \
-     -H "Content-Type: application/json" \
-     -d "${JSON}" \
-     "${API_URL}" | tee -a "${LOG_FILE}"; then
-    echo "Success" | tee -a "${LOG_FILE}"
+  -H "Content-Type: application/json" \
+  -d "${JSON}" \
+  "${API_URL}" | tee -a "${LOG_FILE}"; then
+  echo "Success" | tee -a "${LOG_FILE}"
 else
-    echo "Error: qBit Manage API call failed for hash ${TORRENT_HASH}" | tee -a "${LOG_FILE}"
+  echo "Error: qBit Manage API call failed for hash ${TORRENT_HASH}" | tee -a "${LOG_FILE}"
 fi

--- a/qbm-update.sh
+++ b/qbm-update.sh
@@ -15,49 +15,49 @@ CURRENT_UID=$(id -un)
 
 # Check if QBM is installed and if the current user owns it
 check_qbm_installation() {
-    if [ -d "$QBM_PATH" ]; then
-        qbm_repo_owner=$(stat --format='%U' "$QBM_PATH")
-        qbm_repo_group=$(stat --format='%G' "$QBM_PATH")
-        if [ "$qbm_repo_owner" != "$CURRENT_UID" ]; then
-            echo "You do not own the QbitManage repo. Please run this script as the user that owns the repo [$qbm_repo_owner]."
-            echo "use 'sudo -u $qbm_repo_owner -g $qbm_repo_group qbm-update'"
-            exit 1
-        fi
-    else
-        echo "QbitManage folder does not exist. Please install QbitManage before running this script."
-        exit 1
+  if [ -d "$QBM_PATH" ]; then
+    qbm_repo_owner=$(stat --format='%U' "$QBM_PATH")
+    qbm_repo_group=$(stat --format='%G' "$QBM_PATH")
+    if [ "$qbm_repo_owner" != "$CURRENT_UID" ]; then
+      echo "You do not own the QbitManage repo. Please run this script as the user that owns the repo [$qbm_repo_owner]."
+      echo "use 'sudo -u $qbm_repo_owner -g $qbm_repo_group qbm-update'"
+      exit 1
     fi
+  else
+    echo "QbitManage folder does not exist. Please install QbitManage before running this script."
+    exit 1
+  fi
 }
 
 # Update QBM if necessary
 update_qbm() {
-    current_branch=$(git -C "$QBM_PATH" rev-parse --abbrev-ref HEAD)
-    echo "Current Branch: $current_branch. Checking for updates..."
-    git -C "$QBM_PATH" fetch
-    if [ "$(git -C "$QBM_PATH" rev-parse HEAD)" = "$(git -C "$QBM_PATH" rev-parse @'{u}')" ] && [ "$force_update" != true ]; then
-        current_version=$(cat "$QBM_VERSION_FILE")
-        echo "=== Already up to date $current_version on $current_branch ==="
-        exit 0
-    fi
-    current_requirements=$(sha1sum "$QBM_REQUIREMENTS_FILE" | awk '{print $1}')
-    git -C "$QBM_PATH" reset --hard "$QBM_UPSTREAM_GIT_REMOTE/$current_branch"
+  current_branch=$(git -C "$QBM_PATH" rev-parse --abbrev-ref HEAD)
+  echo "Current Branch: $current_branch. Checking for updates..."
+  git -C "$QBM_PATH" fetch
+  if [ "$(git -C "$QBM_PATH" rev-parse HEAD)" = "$(git -C "$QBM_PATH" rev-parse @'{u}')" ] && [ "$force_update" != true ]; then
+    current_version=$(cat "$QBM_VERSION_FILE")
+    echo "=== Already up to date $current_version on $current_branch ==="
+    exit 0
+  fi
+  current_requirements=$(sha1sum "$QBM_REQUIREMENTS_FILE" | awk '{print $1}')
+  git -C "$QBM_PATH" reset --hard "$QBM_UPSTREAM_GIT_REMOTE/$current_branch"
 }
 
 # Update virtual environment if requirements have changed
 update_venv() {
-    new_requirements=$(sha1sum "$QBM_REQUIREMENTS_FILE" | awk '{print $1}')
-    if [ "$current_requirements" != "$new_requirements" ] || [ "$force_update" = true ]; then
-        echo "=== Requirements changed, updating venv ==="
-        "$QBM_VENV_PATH/bin/python" -m pip  install --upgrade "$QBM_PATH"
-    fi
+  new_requirements=$(sha1sum "$QBM_REQUIREMENTS_FILE" | awk '{print $1}')
+  if [ "$current_requirements" != "$new_requirements" ] || [ "$force_update" = true ]; then
+    echo "=== Requirements changed, updating venv ==="
+    "$QBM_VENV_PATH/bin/python" -m pip install --upgrade "$QBM_PATH"
+  fi
 }
 
 # Restart the QBM service
 restart_service() {
-    echo "=== Restarting QBM Service ==="
-    sudo systemctl restart "$QBM_SERVICE_NAME"
-    new_version=$(cat "$QBM_VERSION_FILE")
-    echo "=== Updated to $new_version on $current_branch"
+  echo "=== Restarting QBM Service ==="
+  sudo systemctl restart "$QBM_SERVICE_NAME"
+  new_version=$(cat "$QBM_VERSION_FILE")
+  echo "=== Updated to $new_version on $current_branch"
 }
 
 # Main script execution

--- a/qui-xseed.sh
+++ b/qui-xseed.sh
@@ -42,52 +42,52 @@ OLD_IFS="$IFS"
 # Only ERROR/WARNING go to stderr (starr captures stderr as |Error| lines which triggers notifiarr alerts)
 # All messages go to the log file for debugging
 log_message() {
-    local log_type="$1"
-    local message="$2"
-    local log_line
-    log_line="$(date '+%Y-%m-%d %H:%M:%S') [$log_type] $message"
-    if [ -n "$LOG_FILE" ] && [ -f "$LOG_FILE" ]; then
-        echo "$log_line" >> "$LOG_FILE"
-    fi
-    if [[ "$log_type" == "ERROR" || "$log_type" == "WARNING" ]]; then
-        echo "$log_line" >&2
-    fi
+  local log_type="$1"
+  local message="$2"
+  local log_line
+  log_line="$(date '+%Y-%m-%d %H:%M:%S') [$log_type] $message"
+  if [ -n "$LOG_FILE" ] && [ -f "$LOG_FILE" ]; then
+    echo "$log_line" >>"$LOG_FILE"
+  fi
+  if [[ "$log_type" == "ERROR" || "$log_type" == "WARNING" ]]; then
+    echo "$log_line" >&2
+  fi
 }
 
 log_message "INFO" "qui-xseed.sh script started $VERSION"
 EVAR=false
 if [ -f "$ENV_PATH" ]; then
-    log_message "INFO" "Loading environment variables from $ENV_PATH file"
-    # shellcheck source=/dev/null
-    if source "$ENV_PATH"; then
-        log_message "INFO" "Environment variables loaded successfully"
-        # Strip carriage returns (\r) in case the .env was edited on Windows
-        QUI_HOST=${QUI_HOST//\r'/}
+  log_message "INFO" "Loading environment variables from $ENV_PATH file"
+  # shellcheck source=/dev/null
+  if source "$ENV_PATH"; then
+    log_message "INFO" "Environment variables loaded successfully"
+    # Strip carriage returns (\r) in case the .env was edited on Windows
+    QUI_HOST=${QUI_HOST//\r'/}
         QUI_PORT=${QUI_PORT//\r'/}
-        QUI_APIKEY=${QUI_APIKEY//\r'/}
+    QUI_APIKEY=${QUI_APIKEY//\r'/}
         QUI_TARGET_INSTANCE_ID=${QUI_TARGET_INSTANCE_ID//\r'/}
-        QUI_QBIT_PATH_PREFIX=${QUI_QBIT_PATH_PREFIX//\r'/}
+    QUI_QBIT_PATH_PREFIX=${QUI_QBIT_PATH_PREFIX//\r'/}
         QUI_TAGS=${QUI_TAGS//\r'/}
-        LOG_FILE=${LOG_FILE//\r'/}
+    LOG_FILE=${LOG_FILE//\r'/}
         LOGID_FILE=${LOGID_FILE//\r'/}
-        TORRENT_CLIENTS=${TORRENT_CLIENTS//\r'/}
+    TORRENT_CLIENTS=${TORRENT_CLIENTS//\r'/}
         USENET_CLIENTS=${USENET_CLIENTS//\r'/}
-        EVAR=true
-    else
-        log_message "ERROR" "Error loading environment variables" >&2
-        exit 2
-    fi
+    EVAR=true
+  else
+    log_message "ERROR" "Error loading environment variables" >&2
+    exit 2
+  fi
 else
-    log_message "DEBUG" ".env file not found in script directory ($ENV_PATH)"
+  log_message "DEBUG" ".env file not found in script directory ($ENV_PATH)"
 fi
 
 if [[ -n "$TORRENT_CLIENTS" || -n "$USENET_CLIENTS" ]]; then
-    IFS=','
-    read -r -a TORRENT_CLIENTS <<<"$TORRENT_CLIENTS"
-    read -r -a USENET_CLIENTS <<<"$USENET_CLIENTS"
+  IFS=','
+  read -r -a TORRENT_CLIENTS <<<"$TORRENT_CLIENTS"
+  read -r -a USENET_CLIENTS <<<"$USENET_CLIENTS"
 else
-    TORRENT_CLIENTS=("Qbit")
-    USENET_CLIENTS=("SABnzbd")
+  TORRENT_CLIENTS=("Qbit")
+  USENET_CLIENTS=("SABnzbd")
 fi
 
 QUI_HOST=${QUI_HOST:-localhost}
@@ -114,61 +114,62 @@ log_message "INFO" "LOG_FILE=$LOG_FILE"
 
 # Function to check if a client is in the allowed list
 is_valid_client() {
-    local client="$1"
-    local client_type="$2"
-    case $client_type in
+  local client="$1"
+  local client_type="$2"
+  case $client_type in
     "torrent")
-        for allowed_client in "${TORRENT_CLIENTS[@]}"; do
-            local clean_allowed
-            clean_allowed=$(echo "$allowed_client" | xargs)
-            if [[ "$client" == "$clean_allowed" ]]; then
-                return 0
-            fi
-        done
-        ;;
+      for allowed_client in "${TORRENT_CLIENTS[@]}"; do
+        local clean_allowed
+        clean_allowed=$(echo "$allowed_client" | xargs)
+        if [[ "$client" == "$clean_allowed" ]]; then
+          return 0
+        fi
+      done
+      ;;
     "usenet")
-        for allowed_client in "${USENET_CLIENTS[@]}"; do
-            local clean_allowed
-            clean_allowed=$(echo "$allowed_client" | xargs)
-            if [[ "$client" == "$clean_allowed" ]]; then
-                return 0
-            fi
-        done
-        ;;
-    esac
-    return 1
+      for allowed_client in "${USENET_CLIENTS[@]}"; do
+        local clean_allowed
+        clean_allowed=$(echo "$allowed_client" | xargs)
+        if [[ "$client" == "$clean_allowed" ]]; then
+          return 0
+        fi
+      done
+      ;;
+  esac
+  return 1
 }
 
 # Function to send three-step request to qui API (Create -> Scan -> Delete)
 qui_dir_scan_request() {
-    local target_path="$1"
+  local target_path="$1"
 
-    # Escape backslashes and double quotes to ensure valid JSON
-    local safe_target_path="${target_path//\\/\\\\}"
-    safe_target_path="${safe_target_path//\"/\\\"}"
+  # Escape backslashes and double quotes to ensure valid JSON
+  local safe_target_path="${target_path//\\/\\\\}"
+  safe_target_path="${safe_target_path//\"/\\\"}"
 
-    # Format tags from comma-separated string to JSON array format
-    local json_tags=""
-    if [ -n "$QUI_TAGS" ]; then
-        IFS=',' read -r -a tag_array <<< "$QUI_TAGS"
-        for i in "${!tag_array[@]}"; do
-            # Trim leading/trailing whitespace
-            local tag_trimmed
-            tag_trimmed=$(echo "${tag_array[$i]}" | xargs)
-            if [ -n "$tag_trimmed" ]; then
-                if [ -z "$json_tags" ]; then
-                    json_tags="\"$tag_trimmed\""
-                else
-                    json_tags="$json_tags, \"$tag_trimmed\""
-                fi
-            fi
-        done
-    fi
+  # Format tags from comma-separated string to JSON array format
+  local json_tags=""
+  if [ -n "$QUI_TAGS" ]; then
+    IFS=',' read -r -a tag_array <<<"$QUI_TAGS"
+    for i in "${!tag_array[@]}"; do
+      # Trim leading/trailing whitespace
+      local tag_trimmed
+      tag_trimmed=$(echo "${tag_array[$i]}" | xargs)
+      if [ -n "$tag_trimmed" ]; then
+        if [ -z "$json_tags" ]; then
+          json_tags="\"$tag_trimmed\""
+        else
+          json_tags="$json_tags, \"$tag_trimmed\""
+        fi
+      fi
+    done
+  fi
 
-    log_message "INFO" "Step 1: Creating dir-scan configuration for path: $target_path"
+  log_message "INFO" "Step 1: Creating dir-scan configuration for path: $target_path"
 
-    local create_payload
-    create_payload=$(cat <<EOF
+  local create_payload
+  create_payload=$(
+    cat <<EOF
     {
       "path": "$safe_target_path",
       "enabled": true,
@@ -178,260 +179,260 @@ qui_dir_scan_request() {
       "tags": [$json_tags]
     }
 EOF
-)
+  )
 
-    local tmp_create
-    tmp_create=$(mktemp)
-    local create_http_code
-    create_http_code=$(curl --silent --write-out "%{http_code}" -X POST "http://$QUI_HOST:$QUI_PORT/api/dir-scan/directories" \
+  local tmp_create
+  tmp_create=$(mktemp)
+  local create_http_code
+  create_http_code=$(curl --silent --write-out "%{http_code}" -X POST "http://$QUI_HOST:$QUI_PORT/api/dir-scan/directories" \
+    -H "X-API-Key: $QUI_APIKEY" \
+    -H "Content-Type: application/json" \
+    -H "accept: application/json" \
+    -d "$create_payload" -o "$tmp_create")
+  local create_curl_exit=$?
+  local create_resp
+  create_resp=$(cat "$tmp_create")
+  rm -f "$tmp_create"
+
+  if [ $create_curl_exit -ne 0 ]; then
+    log_message "ERROR" "Step 1 failed: cURL could not connect to qui API (Exit Code: $create_curl_exit)."
+    echo "000"
+    return
+  fi
+
+  if [[ "$create_http_code" -ge 400 ]]; then
+    log_message "ERROR" "Step 1 failed: qui API returned HTTP $create_http_code. Response: $create_resp"
+    echo "000"
+    return
+  fi
+
+  local dir_id
+  dir_id=$(echo "$create_resp" | grep -o '"id":[0-9]*' | head -n 1 | cut -d':' -f2)
+
+  if [ -z "$dir_id" ]; then
+    log_message "ERROR" "Failed to parse directory ID from qui response. Response: $create_resp"
+    echo "000"
+    return
+  fi
+
+  log_message "INFO" "Successfully registered path. Assigned ID: $dir_id"
+
+  log_message "INFO" "Step 2: Triggering manual scan for Directory ID: $dir_id"
+
+  local tmp_trigger
+  tmp_trigger=$(mktemp)
+  local trigger_resp_code
+  trigger_resp_code=$(curl --silent --write-out "%{http_code}" -X POST "http://$QUI_HOST:$QUI_PORT/api/dir-scan/directories/$dir_id/scan" \
+    -H "X-API-Key: $QUI_APIKEY" \
+    -H "accept: application/json" -o "$tmp_trigger")
+  local trigger_curl_exit=$?
+  local trigger_resp
+  trigger_resp=$(cat "$tmp_trigger")
+  rm -f "$tmp_trigger"
+
+  if [ $trigger_curl_exit -ne 0 ]; then
+    log_message "ERROR" "Step 2 failed: cURL could not connect to qui API (Exit Code: $trigger_curl_exit)."
+  elif [[ "$trigger_resp_code" -ge 400 ]]; then
+    log_message "ERROR" "Step 2 failed: qui API returned HTTP $trigger_resp_code. Response: $trigger_resp"
+  fi
+
+  if [ "$trigger_resp_code" == "202" ]; then
+    log_message "INFO" "Scan successfully queued (202 Accepted). Polling status..."
+
+    # ---------------------------------------------------------
+    # POLLING CONFIGURATION (Exponential Backoff)
+    # ---------------------------------------------------------
+    local current_wait=10      # Starting wait time in seconds
+    local poll_multiplier=2    # Multiplier for the wait time (10, 20, 40, 80...)
+    local max_total_time=86400 # Maximum total time to wait in seconds (86400s = 1 day)
+    # ---------------------------------------------------------
+
+    local elapsed_time=0
+    local attempt=1
+    local scan_done=false
+
+    while [ $elapsed_time -le $max_total_time ]; do
+      local tmp_status
+      tmp_status=$(mktemp)
+      local status_http_code
+      status_http_code=$(curl --silent --write-out "%{http_code}" -X GET "http://$QUI_HOST:$QUI_PORT/api/dir-scan/directories/$dir_id/status" \
         -H "X-API-Key: $QUI_APIKEY" \
-        -H "Content-Type: application/json" \
-        -H "accept: application/json" \
-        -d "$create_payload" -o "$tmp_create")
-    local create_curl_exit=$?
-    local create_resp
-    create_resp=$(cat "$tmp_create")
-    rm -f "$tmp_create"
+        -H "accept: application/json" -o "$tmp_status")
+      local status_curl_exit=$?
+      local status_resp
+      status_resp=$(cat "$tmp_status")
+      rm -f "$tmp_status"
 
-    if [ $create_curl_exit -ne 0 ]; then
-        log_message "ERROR" "Step 1 failed: cURL could not connect to qui API (Exit Code: $create_curl_exit)."
-        echo "000"
-        return
-    fi
+      if [ $status_curl_exit -ne 0 ] || [[ "$status_http_code" -ge 400 ]]; then
+        log_message "WARNING" "Failed to poll status for ID $dir_id (HTTP $status_http_code). Will retry next loop."
+      else
+        local current_status
+        current_status=$(echo "$status_resp" | grep -o '"status":"[^"]*"' | head -n 1 | cut -d'"' -f4)
+        log_message "DEBUG" "Scan status for ID $dir_id: $current_status (Attempt $attempt, Elapsed: ${elapsed_time}s)"
 
-    if [[ "$create_http_code" -ge 400 ]]; then
-        log_message "ERROR" "Step 1 failed: qui API returned HTTP $create_http_code. Response: $create_resp"
-        echo "000"
-        return
-    fi
-
-    local dir_id
-    dir_id=$(echo "$create_resp" | grep -o '"id":[0-9]*' | head -n 1 | cut -d':' -f2)
-
-    if [ -z "$dir_id" ]; then
-        log_message "ERROR" "Failed to parse directory ID from qui response. Response: $create_resp"
-        echo "000"
-        return
-    fi
-
-    log_message "INFO" "Successfully registered path. Assigned ID: $dir_id"
-
-    log_message "INFO" "Step 2: Triggering manual scan for Directory ID: $dir_id"
-
-    local tmp_trigger
-    tmp_trigger=$(mktemp)
-    local trigger_resp_code
-    trigger_resp_code=$(curl --silent --write-out "%{http_code}" -X POST "http://$QUI_HOST:$QUI_PORT/api/dir-scan/directories/$dir_id/scan" \
-        -H "X-API-Key: $QUI_APIKEY" \
-        -H "accept: application/json" -o "$tmp_trigger")
-    local trigger_curl_exit=$?
-    local trigger_resp
-    trigger_resp=$(cat "$tmp_trigger")
-    rm -f "$tmp_trigger"
-
-    if [ $trigger_curl_exit -ne 0 ]; then
-        log_message "ERROR" "Step 2 failed: cURL could not connect to qui API (Exit Code: $trigger_curl_exit)."
-    elif [[ "$trigger_resp_code" -ge 400 ]]; then
-        log_message "ERROR" "Step 2 failed: qui API returned HTTP $trigger_resp_code. Response: $trigger_resp"
-    fi
-
-    if [ "$trigger_resp_code" == "202" ]; then
-        log_message "INFO" "Scan successfully queued (202 Accepted). Polling status..."
-
-        # ---------------------------------------------------------
-        # POLLING CONFIGURATION (Exponential Backoff)
-        # ---------------------------------------------------------
-        local current_wait=10         # Starting wait time in seconds
-        local poll_multiplier=2       # Multiplier for the wait time (10, 20, 40, 80...)
-        local max_total_time=86400    # Maximum total time to wait in seconds (86400s = 1 day)
-        # ---------------------------------------------------------
-
-        local elapsed_time=0
-        local attempt=1
-        local scan_done=false
-
-        while [ $elapsed_time -le $max_total_time ]; do
-            local tmp_status
-            tmp_status=$(mktemp)
-            local status_http_code
-            status_http_code=$(curl --silent --write-out "%{http_code}" -X GET "http://$QUI_HOST:$QUI_PORT/api/dir-scan/directories/$dir_id/status" \
-                -H "X-API-Key: $QUI_APIKEY" \
-                -H "accept: application/json" -o "$tmp_status")
-            local status_curl_exit=$?
-            local status_resp
-            status_resp=$(cat "$tmp_status")
-            rm -f "$tmp_status"
-
-            if [ $status_curl_exit -ne 0 ] || [[ "$status_http_code" -ge 400 ]]; then
-                log_message "WARNING" "Failed to poll status for ID $dir_id (HTTP $status_http_code). Will retry next loop."
-            else
-                local current_status
-                current_status=$(echo "$status_resp" | grep -o '"status":"[^"]*"' | head -n 1 | cut -d'"' -f4)
-                log_message "DEBUG" "Scan status for ID $dir_id: $current_status (Attempt $attempt, Elapsed: ${elapsed_time}s)"
-
-                if [[ "$current_status" == "success" || "$current_status" == "failed" || "$current_status" == "canceled" || "$current_status" == "idle" ]]; then
-                    log_message "INFO" "Scan completed with status: $current_status."
-                    scan_done=true
-                    break
-                fi
-            fi
-
-            if [ $elapsed_time -ge $max_total_time ]; then
-                break
-            fi
-
-            local remaining_time=$((max_total_time - elapsed_time))
-            local sleep_time=$current_wait
-            if [ $sleep_time -gt $remaining_time ]; then
-                sleep_time=$remaining_time
-            fi
-
-            log_message "INFO" "Scan still running. Waiting ${sleep_time}s before next check..."
-            sleep $sleep_time
-
-            elapsed_time=$((elapsed_time + sleep_time))
-            current_wait=$((current_wait * poll_multiplier))
-            attempt=$((attempt + 1))
-        done
-
-        if [ "$scan_done" != true ]; then
-            log_message "WARNING" "Scan polling timed out after $max_total_time seconds. Proceeding to cleanup anyway."
+        if [[ "$current_status" == "success" || "$current_status" == "failed" || "$current_status" == "canceled" || "$current_status" == "idle" ]]; then
+          log_message "INFO" "Scan completed with status: $current_status."
+          scan_done=true
+          break
         fi
+      fi
 
-        log_message "INFO" "Step 3: Deleting directory ID $dir_id to prevent recurring scans."
+      if [ $elapsed_time -ge $max_total_time ]; then
+        break
+      fi
 
-        local tmp_delete
-        tmp_delete=$(mktemp)
-        local delete_resp_code
-        delete_resp_code=$(curl --silent --write-out "%{http_code}" -X DELETE "http://$QUI_HOST:$QUI_PORT/api/dir-scan/directories/$dir_id" \
-            -H "X-API-Key: $QUI_APIKEY" \
-            -H "accept: application/json" -o "$tmp_delete")
-        local delete_curl_exit=$?
-        local delete_resp
-        delete_resp=$(cat "$tmp_delete")
-        rm -f "$tmp_delete"
+      local remaining_time=$((max_total_time - elapsed_time))
+      local sleep_time=$current_wait
+      if [ $sleep_time -gt $remaining_time ]; then
+        sleep_time=$remaining_time
+      fi
 
-        if [ $delete_curl_exit -ne 0 ]; then
-            log_message "ERROR" "Step 3 failed: cURL could not connect to qui API (Exit Code: $delete_curl_exit)."
-        elif [[ "$delete_resp_code" -ge 400 ]]; then
-            log_message "ERROR" "Step 3 failed: qui API returned HTTP $delete_resp_code. Response: $delete_resp"
-        else
-            log_message "INFO" "Directory deletion completed successfully (HTTP $delete_resp_code)."
-        fi
+      log_message "INFO" "Scan still running. Waiting ${sleep_time}s before next check..."
+      sleep $sleep_time
+
+      elapsed_time=$((elapsed_time + sleep_time))
+      current_wait=$((current_wait * poll_multiplier))
+      attempt=$((attempt + 1))
+    done
+
+    if [ "$scan_done" != true ]; then
+      log_message "WARNING" "Scan polling timed out after $max_total_time seconds. Proceeding to cleanup anyway."
+    fi
+
+    log_message "INFO" "Step 3: Deleting directory ID $dir_id to prevent recurring scans."
+
+    local tmp_delete
+    tmp_delete=$(mktemp)
+    local delete_resp_code
+    delete_resp_code=$(curl --silent --write-out "%{http_code}" -X DELETE "http://$QUI_HOST:$QUI_PORT/api/dir-scan/directories/$dir_id" \
+      -H "X-API-Key: $QUI_APIKEY" \
+      -H "accept: application/json" -o "$tmp_delete")
+    local delete_curl_exit=$?
+    local delete_resp
+    delete_resp=$(cat "$tmp_delete")
+    rm -f "$tmp_delete"
+
+    if [ $delete_curl_exit -ne 0 ]; then
+      log_message "ERROR" "Step 3 failed: cURL could not connect to qui API (Exit Code: $delete_curl_exit)."
+    elif [[ "$delete_resp_code" -ge 400 ]]; then
+      log_message "ERROR" "Step 3 failed: qui API returned HTTP $delete_resp_code. Response: $delete_resp"
     else
-        log_message "ERROR" "Failed to trigger scan. Skipping deletion so you can inspect the error in qui."
+      log_message "INFO" "Directory deletion completed successfully (HTTP $delete_resp_code)."
     fi
+  else
+    log_message "ERROR" "Failed to trigger scan. Skipping deletion so you can inspect the error in qui."
+  fi
 
-    # Output ONLY the trigger response code so the main script can evaluate it
-    echo "$trigger_resp_code"
+  # Output ONLY the trigger response code so the main script can evaluate it
+  echo "$trigger_resp_code"
 }
 
 # Detect application and set environment
 detect_application() {
-    app="unknown"
-    if [ -n "$radarr_eventtype" ]; then
-        app="radarr"
-        clientID="$radarr_download_client"
-        downloadID="$radarr_download_id"
-        filePath="$radarr_moviefile_path"
-        eventType="$radarr_eventtype"
-    elif [ -n "$sonarr_eventtype" ]; then
-        app="sonarr"
-        sonarrReleaseType="$sonarr_release_releasetype"
-        clientID="$sonarr_download_client"
-        downloadID="$sonarr_download_id"
-        if [ -n "$sonarrReleaseType" ] && [ "$sonarrReleaseType" == "SeasonPack" ]; then
-            folderPath="$sonarr_destinationpath"
-        else
-            if [ -z "$sonarr_release_releasetype" ]; then
-                folderPath="$sonarr_episodefile_sourcefolder"
-                filePath="$sonarr_episodefile_path"
-            else
-                filePath="$sonarr_episodefile_paths"
-            fi
-        fi
-        eventType="$sonarr_eventtype"
+  app="unknown"
+  if [ -n "$radarr_eventtype" ]; then
+    app="radarr"
+    clientID="$radarr_download_client"
+    downloadID="$radarr_download_id"
+    filePath="$radarr_moviefile_path"
+    eventType="$radarr_eventtype"
+  elif [ -n "$sonarr_eventtype" ]; then
+    app="sonarr"
+    sonarrReleaseType="$sonarr_release_releasetype"
+    clientID="$sonarr_download_client"
+    downloadID="$sonarr_download_id"
+    if [ -n "$sonarrReleaseType" ] && [ "$sonarrReleaseType" == "SeasonPack" ]; then
+      folderPath="$sonarr_destinationpath"
+    else
+      if [ -z "$sonarr_release_releasetype" ]; then
+        folderPath="$sonarr_episodefile_sourcefolder"
+        filePath="$sonarr_episodefile_path"
+      else
+        filePath="$sonarr_episodefile_paths"
+      fi
     fi
+    eventType="$sonarr_eventtype"
+  fi
 
-    if [ "$app" == "unknown" ]; then
-        log_message "ERROR" "Unknown application type detected. Exiting."
-        exit 2
-    fi
-    log_message "INFO" "Detected application: $app"
+  if [ "$app" == "unknown" ]; then
+    log_message "ERROR" "Unknown application type detected. Exiting."
+    exit 2
+  fi
+  log_message "INFO" "Detected application: $app"
 }
 
 # Validate the process
 validate_process() {
-    if [ "$eventType" == "Test" ]; then
-        log_message "INFO" "Test event detected. Exiting."
-        exit 0
-    fi
+  if [ "$eventType" == "Test" ]; then
+    log_message "INFO" "Test event detected. Exiting."
+    exit 0
+  fi
 
-    [ ! -f "$LOG_FILE" ] && touch "$LOG_FILE"
-    [ ! -f "$LOGID_FILE" ] && touch "$LOGID_FILE"
-    unique_id="${downloadID}-${clientID}"
+  [ ! -f "$LOG_FILE" ] && touch "$LOG_FILE"
+  [ ! -f "$LOGID_FILE" ] && touch "$LOGID_FILE"
+  unique_id="${downloadID}-${clientID}"
 
-    if [ -z "$unique_id" ] || [ "$unique_id" == "-" ]; then
-        log_message "ERROR" "Unique ID is missing. Exiting."
-        exit 1
-    fi
+  if [ -z "$unique_id" ] || [ "$unique_id" == "-" ]; then
+    log_message "ERROR" "Unique ID is missing. Exiting."
+    exit 1
+  fi
 
-    if grep -qF "$unique_id" "$LOGID_FILE"; then
-        log_message "INFO" "Download ID [$unique_id] already processed and logged. Exiting."
-        exit 0
-    fi
+  if grep -qF "$unique_id" "$LOGID_FILE"; then
+    log_message "INFO" "Download ID [$unique_id] already processed and logged. Exiting."
+    exit 0
+  fi
 
-    if [ -z "$filePath" ] && [ -z "$folderPath" ]; then
-        log_message "ERROR" "File and Folder paths are missing. qui requires a path. Exiting."
-        exit 2
-    fi
+  if [ -z "$filePath" ] && [ -z "$folderPath" ]; then
+    log_message "ERROR" "File and Folder paths are missing. qui requires a path. Exiting."
+    exit 2
+  fi
 }
 
 # Function to parse paths and send to qui
 send_data_search() {
-    local target_dir=""
+  local target_dir=""
 
-    # qui requires a directory path. If we only have a file, extract its folder.
-    if [ -n "$folderPath" ]; then
-        target_dir="$folderPath"
-    elif [ -n "$filePath" ]; then
-        target_dir="$(dirname "$filePath")"
-    fi
+  # qui requires a directory path. If we only have a file, extract its folder.
+  if [ -n "$folderPath" ]; then
+    target_dir="$folderPath"
+  elif [ -n "$filePath" ]; then
+    target_dir="$(dirname "$filePath")"
+  fi
 
-    if [ -z "$target_dir" ]; then
-        log_message "ERROR" "Could not determine a valid directory path to scan."
-        qui_resp="000"
-        return
-    fi
+  if [ -z "$target_dir" ]; then
+    log_message "ERROR" "Could not determine a valid directory path to scan."
+    qui_resp="000"
+    return
+  fi
 
-    qui_resp=$(qui_dir_scan_request "$target_dir")
+  qui_resp=$(qui_dir_scan_request "$target_dir")
 }
 
 # Main logic for handling operations
 handle_operations() {
-    detect_application
-    validate_process
+  detect_application
+  validate_process
 
-    if is_valid_client "$clientID" "torrent" || is_valid_client "$clientID" "usenet"; then
-        log_message "INFO" "Processing client operations for $clientID..."
-        send_data_search
-    else
-        log_message "ERROR" "Unrecognized client $clientID. Exiting."
-        exit 2
+  if is_valid_client "$clientID" "torrent" || is_valid_client "$clientID" "usenet"; then
+    log_message "INFO" "Processing client operations for $clientID..."
+    send_data_search
+  else
+    log_message "ERROR" "Unrecognized client $clientID. Exiting."
+    exit 2
+  fi
+
+  log_message "INFO" "Final API Pipeline Result Code: $qui_resp"
+
+  if [ "$qui_resp" == "202" ]; then
+    echo "$unique_id" >>"$LOGID_FILE"
+    log_message "INFO" "Process completed successfully. Target processed and cleaned up."
+  else
+    if [ "$qui_resp" == "000" ]; then
+      log_message "ERROR" "Process Timed Out or Failed internal checks. Exiting."
     fi
-
-    log_message "INFO" "Final API Pipeline Result Code: $qui_resp"
-
-    if [ "$qui_resp" == "202" ]; then
-        echo "$unique_id" >>"$LOGID_FILE"
-        log_message "INFO" "Process completed successfully. Target processed and cleaned up."
-    else
-        if [ "$qui_resp" == "000" ]; then
-            log_message "ERROR" "Process Timed Out or Failed internal checks. Exiting."
-        fi
-        log_message "ERROR" "Process failed with HTTP response: $qui_resp"
-        exit 1
-    fi
+    log_message "ERROR" "Process failed with HTTP response: $qui_resp"
+    exit 1
+  fi
 }
 
 handle_operations

--- a/radarr_dupefinder.sh
+++ b/radarr_dupefinder.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-directory=${1:-.}  # Use provided directory or default to current directory
+directory=${1:-.} # Use provided directory or default to current directory
 
 find "$directory" -type d | while read -r dir; do
-    file_count=$(find "$dir" -maxdepth 1 -type f \( -iname "*.mp4" -o -iname "*.mkv" -o -iname "*.avi" -o -iname "*.mov" -o -iname "*.wmv" -o -iname "*.flv" -o -iname "*.webm" -o -iname "*.mpg" -o -iname "*.mpeg" \) | wc -l)
-    if [[ $file_count -gt 1 ]]; then
-        echo "$dir"
-    fi
+  file_count=$(find "$dir" -maxdepth 1 -type f \( -iname "*.mp4" -o -iname "*.mkv" -o -iname "*.avi" -o -iname "*.mov" -o -iname "*.wmv" -o -iname "*.flv" -o -iname "*.webm" -o -iname "*.mpg" -o -iname "*.mpeg" \) | wc -l)
+  if [[ $file_count -gt 1 ]]; then
+    echo "$dir"
+  fi
 done

--- a/servarr/servarr_bot_merge.sh
+++ b/servarr/servarr_bot_merge.sh
@@ -8,23 +8,23 @@ REPO_DIR="/mnt/raid/_development/servarr.wiki"
 
 # Function to log messages
 log() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
 }
 
 # Check and configure git remote
 configure_remote() {
-    # Check if the remote is set and set it if not
-    if git remote | grep -q "origin"; then
-        git remote set-url origin $REPO_URL
-    else
-        git remote add origin $REPO_URL
-    fi
+  # Check if the remote is set and set it if not
+  if git remote | grep -q "origin"; then
+    git remote set-url origin $REPO_URL
+  else
+    git remote add origin $REPO_URL
+  fi
 }
 
 # Navigate to the repository's directory
 cd $REPO_DIR || {
-    log "Failed to change directory to $REPO_DIR. Exiting."
-    exit 1
+  log "Failed to change directory to $REPO_DIR. Exiting."
+  exit 1
 }
 
 # Configure git remote
@@ -43,38 +43,38 @@ log "git branch is $git_branch"
 # Rebase the commit onto the target branch
 log "Rebasing....on origin/$TARGET_BRANCH"
 if git rebase origin/$TARGET_BRANCH; then
-    log "Rebase successful."
+  log "Rebase successful."
 
-    # Switch back to the target branch
-    git checkout $TARGET_BRANCH
+  # Switch back to the target branch
+  git checkout $TARGET_BRANCH
 
-    # Merge the commit branch into the target branch to bring the rebased commit into target
-    # This is assuming the rebase has made commit branch ahead of target and can be fast-forwarded
-    log "Merging into $COMMIT_BRANCH with --ff-only"
-    LOCAL_HASH=$(git rev-parse "$COMMIT_BRANCH")
-    REMOTE_HASH=$(git rev-parse "origin/$COMMIT_BRANCH")
+  # Merge the commit branch into the target branch to bring the rebased commit into target
+  # This is assuming the rebase has made commit branch ahead of target and can be fast-forwarded
+  log "Merging into $COMMIT_BRANCH with --ff-only"
+  LOCAL_HASH=$(git rev-parse "$COMMIT_BRANCH")
+  REMOTE_HASH=$(git rev-parse "origin/$COMMIT_BRANCH")
 
-    if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
-      git merge --ff-only $COMMIT_BRANCH
+  if [ "$LOCAL_HASH" != "$REMOTE_HASH" ]; then
+    git merge --ff-only $COMMIT_BRANCH
+  else
+    echo "Local branch $COMMIT_BRANCH is the same as origin/$COMMIT_BRANCH. No action needed."
+  fi
+  # Now push the updated TARGET_BRANCH to the remote
+  if [ "$LOCAL_HASH" != "$REMOTE_HASH" ] && git push origin $TARGET_BRANCH; then
+    log "Rebase, merge, and push to $TARGET_BRANCH completed successfully."
+    # Check if the branch exists on the remote
+    if git ls-remote --heads origin | grep -q "refs/heads/$COMMIT_BRANCH"; then
+      echo "Branch $COMMIT_BRANCH exists on origin. Deleting..."
+      git push origin --delete "$COMMIT_BRANCH"
+      echo "Branch $COMMIT_BRANCH deleted from origin."
     else
-      echo "Local branch $COMMIT_BRANCH is the same as origin/$COMMIT_BRANCH. No action needed."
+      echo "Branch $COMMIT_BRANCH does not exist on origin."
     fi
-    # Now push the updated TARGET_BRANCH to the remote
-    if [ "$LOCAL_HASH" != "$REMOTE_HASH" ] && git push origin $TARGET_BRANCH; then
-        log "Rebase, merge, and push to $TARGET_BRANCH completed successfully."
-        # Check if the branch exists on the remote
-        if git ls-remote --heads origin | grep -q "refs/heads/$COMMIT_BRANCH"; then
-          echo "Branch $COMMIT_BRANCH exists on origin. Deleting..."
-          git push origin --delete "$COMMIT_BRANCH"
-          echo "Branch $COMMIT_BRANCH deleted from origin."
-        else
-          echo "Branch $COMMIT_BRANCH does not exist on origin."
-        fi
-        git branch -d $COMMIT_BRANCH
-        log "Deleted Local Branch $COMMIT_BRANCH"
-    else
-        log "Updates are on the target branch, no pull request needed."
-    fi
+    git branch -d $COMMIT_BRANCH
+    log "Deleted Local Branch $COMMIT_BRANCH"
+  else
+    log "Updates are on the target branch, no pull request needed."
+  fi
 else
-    log "Rebase encountered conflicts. Resolve them manually and then continue the rebase process."
+  log "Rebase encountered conflicts. Resolve them manually and then continue the rebase process."
 fi

--- a/sonarr_dupefinder.sh
+++ b/sonarr_dupefinder.sh
@@ -1,34 +1,34 @@
 #!/bin/bash
 
-directory=${1:-.}  # Use provided directory or default to current directory
+directory=${1:-.} # Use provided directory or default to current directory
 
 find "$directory" -type d | while read -r dir; do
-    # Extract all matching filenames in the directory
-    # shellcheck disable=SC2207
-    files=($(find "$dir" -maxdepth 1 -type f -regextype posix-extended \
-        \( -iname "*.mp4" -o -iname "*.mkv" -o -iname "*.avi" -o -iname "*.mov" -o -iname "*.wmv" -o -iname "*.flv" -o -iname "*.webm" -o -iname "*.mpg" -o -iname "*.mpeg" \) \
-        -regex ".*\([0-9]{4}\).*S[0-9]{2}E([0-9]{2}).*" | sed -E 's/.*E([0-9]{2}).*/\1/'))
+  # Extract all matching filenames in the directory
+  # shellcheck disable=SC2207
+  files=($(find "$dir" -maxdepth 1 -type f -regextype posix-extended \
+    \( -iname "*.mp4" -o -iname "*.mkv" -o -iname "*.avi" -o -iname "*.mov" -o -iname "*.wmv" -o -iname "*.flv" -o -iname "*.webm" -o -iname "*.mpg" -o -iname "*.mpeg" \) \
+    -regex ".*\([0-9]{4}\).*S[0-9]{2}E([0-9]{2}).*" | sed -E 's/.*E([0-9]{2}).*/\1/'))
 
-    # Count occurrences of each episode number
-    declare -A ep_count
-    for ep in "${files[@]}"; do
-        ((ep_count[$ep]++))
-    done
+  # Count occurrences of each episode number
+  declare -A ep_count
+  for ep in "${files[@]}"; do
+    ((ep_count[$ep]++))
+  done
 
-    # Check if any episode appears more than once
-    matched=0
-    for count in "${ep_count[@]}"; do
-        if [[ $count -gt 1 ]]; then
-            matched=1
-            break
-        fi
-    done
-
-    # Print the directory if it has matching files
-    if [[ $matched -eq 1 ]]; then
-        echo "$dir"
+  # Check if any episode appears more than once
+  matched=0
+  for count in "${ep_count[@]}"; do
+    if [[ $count -gt 1 ]]; then
+      matched=1
+      break
     fi
+  done
 
-    # Clear the associative array for the next directory
-    unset ep_count
+  # Print the directory if it has matching files
+  if [[ $matched -eq 1 ]]; then
+    echo "$dir"
+  fi
+
+  # Clear the associative array for the next directory
+  unset ep_count
 done

--- a/zfsburn.sh
+++ b/zfsburn.sh
@@ -6,17 +6,17 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_PATH="$SCRIPT_DIR/.env"
 if [ -f "$ENV_PATH" ]; then
-    # shellcheck source=.env
-    echo "Loading environment variables from $ENV_PATH file"
-    # shellcheck disable=SC1090 # shellcheck sucks
-    if source "$ENV_PATH"; then
-        echo "Environment variables loaded successfully"
-    else
-        echo "Error loading environment variables" >&2
-        exit 1
-    fi
+  # shellcheck source=.env
+  echo "Loading environment variables from $ENV_PATH file"
+  # shellcheck disable=SC1090 # shellcheck sucks
+  if source "$ENV_PATH"; then
+    echo "Environment variables loaded successfully"
+  else
+    echo "Error loading environment variables" >&2
+    exit 1
+  fi
 else
-    echo ".env file not found in script directory ($ENV_PATH)"
+  echo ".env file not found in script directory ($ENV_PATH)"
 fi
 
 VERBOSE=${VERBOSE:-1}
@@ -28,114 +28,114 @@ MAX_MONTHLY=${MAX_MONTHLY:-3}
 
 # Logging function based on verbosity level
 log() {
-    local level="$1"
-    local message="$2"
-    if ((level == 0)) || ((VERBOSE == 1 && level == 1)); then
-        echo "$message"
-    fi
+  local level="$1"
+  local message="$2"
+  if ((level == 0)) || ((VERBOSE == 1 && level == 1)); then
+    echo "$message"
+  fi
 }
 
 # Bytes to Human Formatting
 bytes_to_human_readable() {
-    local bytes=$1
-    local units=('B' 'KB' 'MB' 'GB' 'TB' 'PB' 'EB' 'ZB' 'YB')
-    local unit=0
+  local bytes=$1
+  local units=('B' 'KB' 'MB' 'GB' 'TB' 'PB' 'EB' 'ZB' 'YB')
+  local unit=0
 
-    while ((bytes > 1024)); do
-        ((bytes /= 1024))
-        ((unit++))
-    done
+  while ((bytes > 1024)); do
+    ((bytes /= 1024))
+    ((unit++))
+  done
 
-    echo "${bytes} ${units[unit]}"
+  echo "${bytes} ${units[unit]}"
 }
 
 # Function to retrieve snapshot counts for a specific snapshot type
 get_snapshot_count() {
-    local snapshot_type="$1"
-    local dataset="$2"
-    local snapshot_count=0
+  local snapshot_type="$1"
+  local dataset="$2"
+  local snapshot_count=0
 
-    # Filter snapshots based on the snapshot type and count them
-    snapshot_count=$(sudo zfs list -t snapshot -o name -r "$dataset" | grep -cE "$dataset@.*$snapshot_type-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}$")
-    # Return the snapshot count as a variable
-    echo "$snapshot_count"
+  # Filter snapshots based on the snapshot type and count them
+  snapshot_count=$(sudo zfs list -t snapshot -o name -r "$dataset" | grep -cE "$dataset@.*$snapshot_type-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{4}$")
+  # Return the snapshot count as a variable
+  echo "$snapshot_count"
 }
 
 # Function to delete snapshots based on frequency limits
 delete_snapshots() {
-    local dataset="$1"
-    local snapshots=()
-    local deleted=0
-    local space_gained=0
+  local dataset="$1"
+  local snapshots=()
+  local deleted=0
+  local space_gained=0
 
-    # Retrieve all snapshots for the dataset
-    readarray -t snapshots < <(sudo zfs list -t snapshot -H -o name -r "$dataset")
+  # Retrieve all snapshots for the dataset
+  readarray -t snapshots < <(sudo zfs list -t snapshot -H -o name -r "$dataset")
 
-    # Info log prior to filtering
-    log 0 "Total snapshots before filtering: [${#snapshots[@]}]"
+  # Info log prior to filtering
+  log 0 "Total snapshots before filtering: [${#snapshots[@]}]"
 
-    # Loop through snapshots and delete based on frequency limits
-    for snapshot in "${snapshots[@]}"; do
-        log 1 "Filtering snapshot: [$snapshot]"
+  # Loop through snapshots and delete based on frequency limits
+  for snapshot in "${snapshots[@]}"; do
+    log 1 "Filtering snapshot: [$snapshot]"
 
-        local snapshot_name=${snapshot##*/}
-        local snapshot_type=${snapshot_name#*_}
-        snapshot_type=${snapshot_type%%-*}
+    local snapshot_name=${snapshot##*/}
+    local snapshot_type=${snapshot_name#*_}
+    snapshot_type=${snapshot_type%%-*}
 
-        if [[ "$snapshot_type" == "frequent" || "$snapshot_type" == "hourly" || "$snapshot_type" == "daily" || "$snapshot_type" == "weekly" || "$snapshot_type" == "monthly" ]]; then
-            log 0 "Processing snapshot: [$snapshot]"
+    if [[ "$snapshot_type" == "frequent" || "$snapshot_type" == "hourly" || "$snapshot_type" == "daily" || "$snapshot_type" == "weekly" || "$snapshot_type" == "monthly" ]]; then
+      log 0 "Processing snapshot: [$snapshot]"
 
-            local max_count=0
-            local current_count=0
+      local max_count=0
+      local current_count=0
 
-            if [[ "$snapshot_type" == "frequent" ]]; then
-                max_count=$MAX_FREQ
-                current_count=$frequent_count
-            elif [[ "$snapshot_type" == "hourly" ]]; then
-                max_count=$MAX_HOURLY
-                current_count=$hourly_count
-            elif [[ "$snapshot_type" == "daily" ]]; then
-                max_count=$MAX_DAILY
-                current_count=$daily_count
-            elif [[ "$snapshot_type" == "weekly" ]]; then
-                max_count=$MAX_WEEKLY
-                current_count=$weekly_count
-            elif [[ "$snapshot_type" == "monthly" ]]; then
-                max_count=$MAX_MONTHLY
-                current_count=$monthly_count
-            fi
+      if [[ "$snapshot_type" == "frequent" ]]; then
+        max_count=$MAX_FREQ
+        current_count=$frequent_count
+      elif [[ "$snapshot_type" == "hourly" ]]; then
+        max_count=$MAX_HOURLY
+        current_count=$hourly_count
+      elif [[ "$snapshot_type" == "daily" ]]; then
+        max_count=$MAX_DAILY
+        current_count=$daily_count
+      elif [[ "$snapshot_type" == "weekly" ]]; then
+        max_count=$MAX_WEEKLY
+        current_count=$weekly_count
+      elif [[ "$snapshot_type" == "monthly" ]]; then
+        max_count=$MAX_MONTHLY
+        current_count=$monthly_count
+      fi
 
-            log 1 "Current snapshot count: [$current_count]"
-            log 1 "Maximum allowed: [$max_count]"
+      log 1 "Current snapshot count: [$current_count]"
+      log 1 "Maximum allowed: [$max_count]"
 
-            if ((current_count > max_count || max_count == 0)); then
-                log 0 "Deleting snapshot: [$snapshot]"
+      if ((current_count > max_count || max_count == 0)); then
+        log 0 "Deleting snapshot: [$snapshot]"
 
-                local snapshot_space
-                snapshot_space=$(sudo zfs list -o used -H -p "$snapshot" | awk '{print $1}')
+        local snapshot_space
+        snapshot_space=$(sudo zfs list -o used -H -p "$snapshot" | awk '{print $1}')
 
-                if sudo zfs destroy "$snapshot"; then
-                    ((deleted++))
-                    ((space_gained += snapshot_space))
-                    snapshot_space_formatted=$(bytes_to_human_readable "$snapshot_space")
-                    log 0 "Space gained: $snapshot_space_formatted"
-                else
-                    log 0 "Error deleting snapshot: [$snapshot]"
-                fi
-            fi
+        if sudo zfs destroy "$snapshot"; then
+          ((deleted++))
+          ((space_gained += snapshot_space))
+          snapshot_space_formatted=$(bytes_to_human_readable "$snapshot_space")
+          log 0 "Space gained: $snapshot_space_formatted"
         else
-            log 1 "Skipped processing snapshot: [$snapshot] - no match to type: [$snapshot_type]"
+          log 0 "Error deleting snapshot: [$snapshot]"
         fi
-    done
+      fi
+    else
+      log 1 "Skipped processing snapshot: [$snapshot] - no match to type: [$snapshot_type]"
+    fi
+  done
 
-    space_gained_formatted=$(bytes_to_human_readable "$space_gained")
-    log 0 "Deleted $deleted snapshots for dataset: [$dataset]. Total space gained: $space_gained_formatted"
+  space_gained_formatted=$(bytes_to_human_readable "$space_gained")
+  log 0 "Deleted $deleted snapshots for dataset: [$dataset]. Total space gained: $space_gained_formatted"
 }
 
 # Usage: ./zfsburn.sh <dataset>
 if [[ $# -lt 1 ]]; then
-    echo "Usage: ./zfsburn.sh <dataset>"
-    exit 1
+  echo "Usage: ./zfsburn.sh <dataset>"
+  exit 1
 fi
 
 # Capture the dataset as a variable


### PR DESCRIPTION
## Summary
- Restores Pre-commit CI to green. Repo's main has been failing since 2026-04-18 because pre-commit-config pinned shfmt v3.13.1-1, but the repo files were formatted by an older shfmt version with different rules.
- Pure formatting changes — no semantic effects.

## Changes
- 4-space → 2-space indent
- pipe-at-EOL → `\` continuation with pipe-at-BOL (`--binary-next-line` flag)
- minor whitespace normalisation

12 `.sh` files touched; `shellcheck --severity=warning` clean across all.

## Test plan
- [ ] Pre-commit CI passes (it's been red for 3 weeks; this should fix it)
- [ ] shfmt --diff is empty repo-wide after merge
- [ ] No behavioral changes (formatting only)

## Notes
This unblocks #38 (qbm-qbit + notifiarr-branch-builder cherry-pick), which inherits the broken Pre-commit run from main.